### PR TITLE
Add complete data models and service to log audit events

### DIFF
--- a/src/main/kotlin/uk/bfi/uvaudit/app.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/app.kt
@@ -1,23 +1,36 @@
 package uk.bfi.uvaudit
 
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Bean
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import uk.bfi.uvaudit.event.console.LoggingAuditEventWriter
+import uk.bfi.uvaudit.security.AuditUserService
 
-@Configuration
-class ViewerAuditSecurity : WebSecurityConfigurerAdapter() {
+
+@SpringBootApplication
+class ViewerAuditApplication : WebSecurityConfigurerAdapter() {
+    @Autowired
+    lateinit var auditUserService: AuditUserService
+
     override fun configure(http: HttpSecurity) {
         http.authorizeRequests()
             .anyRequest().authenticated()
-            .and().oauth2Login()
+            .and().oauth2Login().userInfoEndpoint {
+                it.oidcUserService(auditUserService)
+            }
             .and().csrf().disable()
     }
-}
 
-@SpringBootApplication
-class ViewerAuditApplication
+    @Bean
+    fun auditUserService() = AuditUserService()
+
+    // @TODO: Replace this with a MySQL backend.
+    @Bean
+    fun auditEventWriter() = LoggingAuditEventWriter()
+}
 
 fun main(args: Array<String>) {
     runApplication<ViewerAuditApplication>(*args)

--- a/src/main/kotlin/uk/bfi/uvaudit/event/AuditEvent.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/event/AuditEvent.kt
@@ -6,6 +6,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 sealed class AuditEvent  {
-    @JsonTypeName("canvas_viewed")
-    data class CanvasChanged(val id: String) : AuditEvent()
+    @JsonTypeName("download_panel_opened")
+    data class DownloadPanelOpened(val manifest: String, val canvas: String) : AuditEvent()
+
+    @JsonTypeName("resource_loaded")
+    data class ResourceLoaded(val uri: String) : AuditEvent()
+
+    @JsonTypeName("image_changed")
+    data class ImageChanged(val manifest: String, val canvas: String)
 }

--- a/src/main/kotlin/uk/bfi/uvaudit/event/AuditEventWriter.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/event/AuditEventWriter.kt
@@ -1,0 +1,10 @@
+package uk.bfi.uvaudit.event
+
+/**
+ * A mechanism for associating [AuditEvent]s with users and writing them back to
+ * persistent storage.
+ */
+interface AuditEventWriter {
+
+    fun write(user: Long, event: AuditEvent)
+}

--- a/src/main/kotlin/uk/bfi/uvaudit/event/console/LoggingAuditEventWriter.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/event/console/LoggingAuditEventWriter.kt
@@ -1,0 +1,17 @@
+package uk.bfi.uvaudit.event.console
+
+import mu.KotlinLogging
+import uk.bfi.uvaudit.event.AuditEvent
+import uk.bfi.uvaudit.event.AuditEventWriter
+
+
+/**
+ * A simple [AuditEventWriter] implementation that writes [AuditEvent]s to the console via SLF4J logging.
+ */
+class LoggingAuditEventWriter : AuditEventWriter {
+    private val logger = KotlinLogging.logger {}
+
+    override fun write(user: Long, event: AuditEvent) {
+        logger.info { "User $user sent $event" }
+    }
+}

--- a/src/main/kotlin/uk/bfi/uvaudit/security/AuditUser.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/security/AuditUser.kt
@@ -1,0 +1,5 @@
+package uk.bfi.uvaudit.security
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+
+class AuditUser(val id: Long, val delegate: OidcUser) : OidcUser by delegate

--- a/src/main/kotlin/uk/bfi/uvaudit/security/AuditUserService.kt
+++ b/src/main/kotlin/uk/bfi/uvaudit/security/AuditUserService.kt
@@ -1,0 +1,19 @@
+package uk.bfi.uvaudit.security
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+
+
+class AuditUserService(
+    private val delegate: OidcUserService = OidcUserService()
+) : OidcUserService() {
+
+    @Throws(OAuth2AuthenticationException::class)
+    override fun loadUser(userRequest: OidcUserRequest): AuditUser {
+        val oidcUser = delegate.loadUser(userRequest)
+        val id = 1L
+
+        return AuditUser(id, oidcUser)
+    }
+}

--- a/src/test/kotlin/uk/bfi/uvaudit/event/AuditEventControllerTests.kt
+++ b/src/test/kotlin/uk/bfi/uvaudit/event/AuditEventControllerTests.kt
@@ -1,0 +1,19 @@
+package uk.bfi.uvaudit.event
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class AuditEventControllerTests {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    @Throws(Exception::class)
+    fun `user should be loaded from AuditUserService`() {
+        // TODO: need fake credentials to simulate oauth2 logins
+    }
+}


### PR DESCRIPTION
- Adds a mechanism to connect OIDC/Auth0 users to a unique ID from the database.
- Adds an interface that logs AuditEvents that we will swap out for a MySQL backend.